### PR TITLE
Create Dimensionality Reduction visualizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ cython_debug/
 TCGA/downloads
 TCGA/annotations/*
 !TCGA/annotations/test_annotation.json
+TCGA/TSNE/results/*

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Any additional requirements can be installed with the following command:
 
 5. View TSNE Visualizations
 
-    python -m TCGA.TSNE.scikit
+    python -m TCGA.TSNE.display_tsne
 
 
 [girder-link]: https://girder.readthedocs.io/

--- a/README.md
+++ b/README.md
@@ -32,5 +32,9 @@ Any additional requirements can be installed with the following command:
 
     python -m TCGA.upload_annotations
 
+5. View TSNE Visualizations
+
+    python -m TCGA.TSNE.scikit
+
 
 [girder-link]: https://girder.readthedocs.io/

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Any additional requirements can be installed with the following command:
 ## TCGA Example
 1. Download example data (this may take up to 30 minutes)
 
-    python TCGA/download_examples.py
+    python -m  TCGA.download_examples
 
 2. Upload images to Girder
 
-    python TCGA/upload_images.py
+    python -m TCGA.upload_images
 
 3. Create annotation file from feature vector data
 
-    python TCGA/write_annotations.py
+    python -m TCGA.write_annotations
 
 4. Upload annotations to Girder
 
-    python TCGA/upload_annotations.py
+    python -m TCGA.upload_annotations
 
 
 [girder-link]: https://girder.readthedocs.io/

--- a/TCGA/TSNE/display_tsne.py
+++ b/TCGA/TSNE/display_tsne.py
@@ -16,7 +16,11 @@ LIBRARY = 'scikit'
 PERPLEXITIES = [5, 30, 50, 100]
 NUM_COMPONENTS = 2
 MAX_ITERATIONS = 300
-NUM_ROIS = 3
+ROIS = [
+    "TCGA-3C-AALI-01Z-00-DX1_roi-2_left-15953_top-51923_right-18001_bottom-53971",
+    "TCGA-3C-AALI-01Z-00-DX1_roi-3_left-15953_top-53971_right-18001_bottom-56019",
+    "TCGA-3C-AALI-01Z-00-DX1_roi-4_left-15953_top-56019_right-18001_bottom-58067",
+]
 
 with open(COLUMN_NAMES) as f:
     column_names = json.load(f)
@@ -27,56 +31,53 @@ for case in DOWNLOADS_FOLDER.glob('*'):
     case_features = []
     case_name = case.name.split('.')[0]
 
-    for roi_csv in list((case / 'nucleiMeta').glob('*.csv'))[:NUM_ROIS]:
-        roiname = roi_csv.name.replace('.csv', '')
-        print(roiname)
-        main_axes = None
-        fig = plt.figure(figsize=(15, 15), layout='tight')
-        fig.suptitle(roiname)
-        for i, perplexity in enumerate(PERPLEXITIES):
-            if LIBRARY == 'scikit':
-                result = get_scikit_tsne_result(
-                    case_name,
-                    roiname,
-                    perplexity=perplexity,
-                    n_components=NUM_COMPONENTS,
-                    max_iterations=MAX_ITERATIONS,
-                    color_label_key=COLOR_LABEL_KEY,
-                )
-            else:
-                raise ValueError(f'Unknown library "{LIBRARY}". Options are ["scikit"].')
+    main_axes = None
+    fig = plt.figure(figsize=(15, 15), layout='tight')
+    fig.suptitle("TSNE Results")
+    for i, perplexity in enumerate(PERPLEXITIES):
+        if LIBRARY == 'scikit':
+            result = get_scikit_tsne_result(
+                case_name,
+                ROIS,
+                perplexity=perplexity,
+                n_components=NUM_COMPONENTS,
+                max_iterations=MAX_ITERATIONS,
+                color_label_key=COLOR_LABEL_KEY,
+            )
+        else:
+            raise ValueError(f'Unknown library "{LIBRARY}". Options are ["scikit"].')
 
-            if result is not None:
-                components = [result[['x', 'y', 'z'][i]] for i in range(NUM_COMPONENTS)]
-                ax = fig.add_subplot(
-                    1,
-                    len(PERPLEXITIES),
-                    i + 1,
-                    sharex=main_axes,
-                    sharey=main_axes,
-                    title=f"Perplexity={perplexity}",
-                    projection='3d' if NUM_COMPONENTS == 3 else None,
-                )
-                ax.scatter(
-                    *components,
-                    c=result['c'],
-                    s=2,
-                    cmap=COLORMAP
-                )
-                if main_axes is None:
-                    main_axes = ax
+        if result is not None:
+            components = [result[['x', 'y', 'z'][i]] for i in range(NUM_COMPONENTS)]
+            ax = fig.add_subplot(
+                1,
+                len(PERPLEXITIES),
+                i + 1,
+                sharex=main_axes,
+                sharey=main_axes,
+                title=f"Perplexity={perplexity}",
+                projection='3d' if NUM_COMPONENTS == 3 else None,
+            )
+            ax.scatter(
+                *components,
+                c=result['c'],
+                s=2,
+                cmap=COLORMAP
+            )
+            if main_axes is None:
+                main_axes = ax
 
 
-        cbar = fig.colorbar(
-            cm.ScalarMappable(cmap=COLORMAP),
-            ax=ax,
-            label='Classification',
-        )
-        yticks = numpy.linspace(*cbar.ax.get_ylim(), len(COLOR_LABEL_KEY) + 1)[:-1]
-        yticks += (yticks[1] - yticks[0]) / 2
-        cbar.set_ticks(
-            yticks,
-            labels=[c.replace(CLASSIF_PREFIX, '') for c in COLOR_LABEL_KEY.keys()],
-        )
-        cbar.ax.tick_params(length=0)
-        plt.show()
+    cbar = fig.colorbar(
+        cm.ScalarMappable(cmap=COLORMAP),
+        ax=ax,
+        label='Classification',
+    )
+    yticks = numpy.linspace(*cbar.ax.get_ylim(), len(COLOR_LABEL_KEY) + 1)[:-1]
+    yticks += (yticks[1] - yticks[0]) / 2
+    cbar.set_ticks(
+        yticks,
+        labels=[c.replace(CLASSIF_PREFIX, '') for c in COLOR_LABEL_KEY.keys()],
+    )
+    cbar.ax.tick_params(length=0)
+    plt.show()

--- a/TCGA/TSNE/display_tsne.py
+++ b/TCGA/TSNE/display_tsne.py
@@ -1,0 +1,82 @@
+import json
+import numpy
+from pathlib import Path
+import matplotlib.pyplot as plt
+import matplotlib.cm as cm
+
+from .scikit import get_tsne_result as get_scikit_tsne_result
+
+
+DOWNLOADS_FOLDER = Path(__file__).parent.parent / 'downloads'
+COLUMN_NAMES = Path(__file__).parent.parent / 'column_names.json'
+CLASSIF_PREFIX = 'Unconstrained.ClassifProbab.'
+COLORMAP = 'Set1'
+
+LIBRARY = 'scikit'
+PERPLEXITIES = [5, 30, 50, 100]
+NUM_COMPONENTS = 2
+MAX_ITERATIONS = 300
+NUM_ROIS = 3
+
+with open(COLUMN_NAMES) as f:
+    column_names = json.load(f)
+    classif_columns = [c for c in column_names if c.startswith(CLASSIF_PREFIX)]
+    COLOR_LABEL_KEY = {c: i for i, c in enumerate(classif_columns)}
+
+for case in DOWNLOADS_FOLDER.glob('*'):
+    case_features = []
+    case_name = case.name.split('.')[0]
+
+    for roi_csv in list((case / 'nucleiMeta').glob('*.csv'))[:NUM_ROIS]:
+        roiname = roi_csv.name.replace('.csv', '')
+        print(roiname)
+        main_axes = None
+        fig = plt.figure(figsize=(15, 15), layout='tight')
+        fig.suptitle(roiname)
+        for i, perplexity in enumerate(PERPLEXITIES):
+            if LIBRARY == 'scikit':
+                result = get_scikit_tsne_result(
+                    case_name,
+                    roiname,
+                    perplexity=perplexity,
+                    n_components=NUM_COMPONENTS,
+                    max_iterations=MAX_ITERATIONS,
+                    color_label_key=COLOR_LABEL_KEY,
+                )
+            else:
+                raise ValueError(f'Unknown library "{LIBRARY}". Options are ["scikit"].')
+
+            if result is not None:
+                components = [result[['x', 'y', 'z'][i]] for i in range(NUM_COMPONENTS)]
+                ax = fig.add_subplot(
+                    1,
+                    len(PERPLEXITIES),
+                    i + 1,
+                    sharex=main_axes,
+                    sharey=main_axes,
+                    title=f"Perplexity={perplexity}",
+                    projection='3d' if NUM_COMPONENTS == 3 else None,
+                )
+                ax.scatter(
+                    *components,
+                    c=result['c'],
+                    s=2,
+                    cmap=COLORMAP
+                )
+                if main_axes is None:
+                    main_axes = ax
+
+
+        cbar = fig.colorbar(
+            cm.ScalarMappable(cmap=COLORMAP),
+            ax=ax,
+            label='Classification',
+        )
+        yticks = numpy.linspace(*cbar.ax.get_ylim(), len(COLOR_LABEL_KEY) + 1)[:-1]
+        yticks += (yticks[1] - yticks[0]) / 2
+        cbar.set_ticks(
+            yticks,
+            labels=[c.replace(CLASSIF_PREFIX, '') for c in COLOR_LABEL_KEY.keys()],
+        )
+        cbar.ax.tick_params(length=0)
+        plt.show()

--- a/TCGA/TSNE/display_tsne.py
+++ b/TCGA/TSNE/display_tsne.py
@@ -3,6 +3,7 @@ import numpy
 from pathlib import Path
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
+from matplotlib import colormaps
 
 from .scikit import get_tsne_result as get_scikit_tsne_result
 
@@ -10,7 +11,7 @@ from .scikit import get_tsne_result as get_scikit_tsne_result
 DOWNLOADS_FOLDER = Path(__file__).parent.parent / 'downloads'
 COLUMN_NAMES = Path(__file__).parent.parent / 'column_names.json'
 CLASSIF_PREFIX = 'Unconstrained.ClassifProbab.'
-COLORMAP = 'Set1'
+COLORMAP = colormaps['Set1']
 
 LIBRARY = 'scikit'
 PERPLEXITIES = [5, 30, 50, 100]

--- a/TCGA/TSNE/display_tsne.py
+++ b/TCGA/TSNE/display_tsne.py
@@ -1,32 +1,21 @@
-import json
 import numpy
-from pathlib import Path
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
-from matplotlib import colormaps
 
-from .scikit import get_tsne_result as get_scikit_tsne_result
+from .scikit import get_tsne_result
+from ..constants import (
+    DOWNLOADS_FOLDER,
+    COLUMN_NAMES,
+    CLASSIF_PREFIX,
+    COLORMAP,
+    COLOR_LABEL_KEY,
+    ROIS
+)
 
-
-DOWNLOADS_FOLDER = Path(__file__).parent.parent / 'downloads'
-COLUMN_NAMES = Path(__file__).parent.parent / 'column_names.json'
-CLASSIF_PREFIX = 'Unconstrained.ClassifProbab.'
-COLORMAP = colormaps['Set1']
-
-LIBRARY = 'scikit'
 PERPLEXITIES = [5, 30, 50, 100]
 NUM_COMPONENTS = 2
 MAX_ITERATIONS = 300
-ROIS = [
-    "TCGA-3C-AALI-01Z-00-DX1_roi-2_left-15953_top-51923_right-18001_bottom-53971",
-    "TCGA-3C-AALI-01Z-00-DX1_roi-3_left-15953_top-53971_right-18001_bottom-56019",
-    "TCGA-3C-AALI-01Z-00-DX1_roi-4_left-15953_top-56019_right-18001_bottom-58067",
-]
 
-with open(COLUMN_NAMES) as f:
-    column_names = json.load(f)
-    classif_columns = [c for c in column_names if c.startswith(CLASSIF_PREFIX)]
-    COLOR_LABEL_KEY = {c: i for i, c in enumerate(classif_columns)}
 
 for case in DOWNLOADS_FOLDER.glob('*'):
     case_features = []
@@ -36,18 +25,14 @@ for case in DOWNLOADS_FOLDER.glob('*'):
     fig = plt.figure(figsize=(15, 15), layout='tight')
     fig.suptitle("TSNE Results")
     for i, perplexity in enumerate(PERPLEXITIES):
-        if LIBRARY == 'scikit':
-            result = get_scikit_tsne_result(
-                case_name,
-                ROIS,
-                perplexity=perplexity,
-                n_components=NUM_COMPONENTS,
-                max_iterations=MAX_ITERATIONS,
-                color_label_key=COLOR_LABEL_KEY,
-            )
-        else:
-            raise ValueError(f'Unknown library "{LIBRARY}". Options are ["scikit"].')
-
+        result = get_tsne_result(
+            case_name,
+            ROIS,
+            perplexity=perplexity,
+            n_components=NUM_COMPONENTS,
+            max_iterations=MAX_ITERATIONS,
+            color_label_key=COLOR_LABEL_KEY,
+        )
         if result is not None:
             components = [result[['x', 'y', 'z'][i]] for i in range(NUM_COMPONENTS)]
             ax = fig.add_subplot(

--- a/TCGA/TSNE/display_umap.py
+++ b/TCGA/TSNE/display_umap.py
@@ -1,0 +1,49 @@
+import numpy
+import matplotlib.pyplot as plt
+import matplotlib.cm as cm
+
+from .umap import get_umap_result
+from ..constants import (
+    DOWNLOADS_FOLDER,
+    COLUMN_NAMES,
+    CLASSIF_PREFIX,
+    COLORMAP,
+    COLOR_LABEL_KEY,
+    ROIS
+)
+
+
+for case in DOWNLOADS_FOLDER.glob('*'):
+    case_features = []
+    case_name = case.name.split('.')[0]
+
+    fig = plt.figure(figsize=(15, 15), layout='tight')
+    fig.suptitle("UMAP Results")
+    result = get_umap_result(
+        case_name,
+        ROIS,
+        color_label_key=COLOR_LABEL_KEY,
+    )
+    if result is not None:
+        ax = plt.axes()
+        ax.scatter(
+            result['x'],
+            result['y'],
+            c=result['c'],
+            s=2,
+            cmap=COLORMAP
+        )
+
+        cbar = fig.colorbar(
+            cm.ScalarMappable(cmap=COLORMAP),
+            ax=ax,
+            label='Classification',
+        )
+        yticks = numpy.linspace(*cbar.ax.get_ylim(), len(COLOR_LABEL_KEY) + 1)[:-1]
+        yticks += (yticks[1] - yticks[0]) / 2
+        cbar.set_ticks(
+            yticks,
+            labels=[c.replace(CLASSIF_PREFIX, '') for c in COLOR_LABEL_KEY.keys()],
+        )
+        cbar.ax.tick_params(length=0)
+        plt.show()

--- a/TCGA/TSNE/scikit.py
+++ b/TCGA/TSNE/scikit.py
@@ -1,0 +1,58 @@
+import pandas
+from pathlib import Path
+from datetime import datetime
+import matplotlib.pyplot as plt
+from sklearn import manifold
+
+from ..read_vectors import get_case_vector
+
+
+DOWNLOADS_FOLDER = Path(__file__).parent.parent / 'downloads'
+PERPLEXITIES = [5, 30, 50, 100]
+N_COMPONENTS = 3
+
+
+for case in DOWNLOADS_FOLDER.glob('*'):
+    case_features = []
+    case_name = case.name.split('.')[0]
+
+    print(f'{case_name}')
+    (fig, subplots) = plt.subplots(1, 4, figsize=(15, len(PERPLEXITIES)))
+    vector = get_case_vector(case_name)
+
+    # whole vectors take 40-70 minutes; test with just one ROI
+    # comment the following two lines to compute whole image:
+    target_roi = vector['roiname'].mode()[0]
+    vector = vector[vector['roiname'] == target_roi]
+
+    # remove any columns that cannot be cast to float
+    vector.drop(
+        [c for c in vector.columns if str(vector[c].dtype) != 'float64'],
+        axis=1,
+        inplace=True
+    )
+    vector.fillna(-1, inplace=True)
+
+    for i, perplexity in enumerate(PERPLEXITIES):
+        print(f'\tEvaluating TSNE with perplexity={perplexity} for {len(vector)} features...')
+        start = datetime.now()
+        ax = subplots[i]
+
+        tsne = manifold.TSNE(
+            n_components=N_COMPONENTS,
+            init="random",
+            random_state=0,
+            perplexity=perplexity,
+            max_iter=300,
+        )
+        result = tsne.fit_transform(vector.to_numpy())
+        print(f'\tCompleted TSNE evaluation  in {datetime.now() - start} seconds.')
+
+        ax.set_title(f"Perplexity={perplexity}")
+        ax.scatter(
+            result[:, 0],
+            result[:, 1],
+            c=(result[:, 2] if N_COMPONENTS == 3 else 'g'),
+        )
+
+plt.show()

--- a/TCGA/TSNE/scikit.py
+++ b/TCGA/TSNE/scikit.py
@@ -1,6 +1,4 @@
-import json
 import pandas
-import numpy
 from pathlib import Path
 from datetime import datetime
 import matplotlib.pyplot as plt
@@ -10,27 +8,20 @@ from sklearn import manifold
 from ..read_vectors import get_case_vector
 
 
-DOWNLOADS_FOLDER = Path(__file__).parent.parent / 'downloads'
 RESULTS_FOLDER = Path(__file__).parent / 'results'
-COLUMN_NAMES = Path(__file__).parent.parent / 'column_names.json'
-CLASSIF_PREFIX = 'Unconstrained.ClassifProbab.'
-COLORMAP = 'Set1'
-
-PERPLEXITIES = [5, 30, 50, 100]
-NUM_COMPONENTS = 2
-MAX_ITERATIONS = 300
-NUM_ROIS = 3
-
-with open(COLUMN_NAMES) as f:
-    column_names = json.load(f)
-    classif_columns = [c for c in column_names if c.startswith(CLASSIF_PREFIX)]
-    COLOR_LABEL_KEY = {c: i for i, c in enumerate(classif_columns)}
 
 
-def get_tsne_result(case_name, roiname, n_components=2, perplexity=100):
+def get_tsne_result(
+    case_name,
+    roiname,
+    n_components=2,
+    perplexity=100,
+    max_iterations=300,
+    color_label_key=None
+):
     filepath = RESULTS_FOLDER / 'scikit' / case_name / f'{n_components}_components' / f'perplexity_{perplexity}' / roiname
     if filepath.exists():
-        return pandas.read_csv(filepath)
+        return pandas.read_csv(filepath, index_col=0)
     else:
         if not filepath.parent.exists():
             filepath.parent.mkdir(parents=True, exist_ok=True)
@@ -43,7 +34,10 @@ def get_tsne_result(case_name, roiname, n_components=2, perplexity=100):
             inplace=True
         )
         vector.fillna(-1, inplace=True)
-        colors = [COLOR_LABEL_KEY[c] for c in vector[COLOR_LABEL_KEY.keys()].idxmax(axis=1)]
+        if color_label_key is not None:
+            colors = [color_label_key[c] for c in vector[color_label_key.keys()].idxmax(axis=1)]
+        else:
+            colors = []
         print(f'\tEvaluating TSNE with perplexity={perplexity} for {len(vector)} features...')
         start = datetime.now()
         tsne = manifold.TSNE(
@@ -51,7 +45,7 @@ def get_tsne_result(case_name, roiname, n_components=2, perplexity=100):
             perplexity=perplexity,
             init="random",
             random_state=0,
-            max_iter=MAX_ITERATIONS,
+            max_iter=max_iterations,
         )
         try:
             result = tsne.fit_transform(vector.to_numpy())
@@ -65,50 +59,3 @@ def get_tsne_result(case_name, roiname, n_components=2, perplexity=100):
             return df
         except Exception as e:
             print('\tSkipping TSNE Evaluation:', str(e))
-
-
-for case in DOWNLOADS_FOLDER.glob('*'):
-    case_features = []
-    case_name = case.name.split('.')[0]
-
-    for roi_csv in list((case / 'nucleiMeta').glob('*.csv'))[:NUM_ROIS]:
-        roiname = roi_csv.name.replace('.csv', '')
-        print(roiname)
-        main_axes = None
-        fig = plt.figure(figsize=(15, 15), layout='tight')
-        fig.suptitle(roiname)
-        for i, perplexity in enumerate(PERPLEXITIES):
-            result = get_tsne_result(case_name, roiname, NUM_COMPONENTS, perplexity)
-            if result is not None:
-                components = [result[['x', 'y', 'z'][i]] for i in range(NUM_COMPONENTS)]
-                ax = fig.add_subplot(
-                    1,
-                    len(PERPLEXITIES),
-                    i + 1,
-                    sharex=main_axes,
-                    sharey=main_axes,
-                    title=f"Perplexity={perplexity}",
-                    projection='3d' if NUM_COMPONENTS == 3 else None,
-                )
-                ax.scatter(
-                    *components,
-                    c=result['c'],
-                    s=2,
-                    cmap=COLORMAP
-                )
-                if main_axes is None:
-                    main_axes = ax
-
-        cbar = fig.colorbar(
-            cm.ScalarMappable(cmap=COLORMAP),
-            ax=ax,
-            label='Classification',
-        )
-        yticks = numpy.linspace(*cbar.ax.get_ylim(), len(COLOR_LABEL_KEY) + 1)[:-1]
-        yticks += (yticks[1] - yticks[0]) / 2
-        cbar.set_ticks(
-            yticks,
-            labels=[c.replace(CLASSIF_PREFIX, '') for c in COLOR_LABEL_KEY.keys()],
-        )
-        cbar.ax.tick_params(length=0)
-        plt.show()

--- a/TCGA/TSNE/scikit.py
+++ b/TCGA/TSNE/scikit.py
@@ -5,7 +5,7 @@ import matplotlib.cm as cm
 from sklearn import manifold
 
 from ..read_vectors import get_case_vector
-from ..constants import TSNE_RESULTS_FOLDER
+from ..constants import TSNE_RESULTS_FOLDER, TSNE_EXCLUDE_COLUMNS
 
 
 def get_tsne_result(
@@ -26,7 +26,10 @@ def get_tsne_result(
         vector = get_case_vector(case_name, rois=rois)
         # remove any columns that cannot be cast to float
         vector.drop(
-            [c for c in vector.columns if str(vector[c].dtype) != 'float64'],
+            [
+                c for c in vector.columns
+                if str(vector[c].dtype) != 'float64' or c in TSNE_EXCLUDE_COLUMNS
+            ],
             axis=1,
             inplace=True
         )

--- a/TCGA/TSNE/scikit.py
+++ b/TCGA/TSNE/scikit.py
@@ -1,14 +1,11 @@
 import pandas
-from pathlib import Path
 from datetime import datetime
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
 from sklearn import manifold
 
 from ..read_vectors import get_case_vector
-
-
-RESULTS_FOLDER = Path(__file__).parent / 'results'
+from ..constants import TSNE_RESULTS_FOLDER
 
 
 def get_tsne_result(
@@ -19,7 +16,7 @@ def get_tsne_result(
     max_iterations=300,
     color_label_key=None
 ):
-    filepath = RESULTS_FOLDER / 'scikit' / case_name / f'{n_components}_components' / f'perplexity_{perplexity}' / '&'.join(rois)
+    filepath = TSNE_RESULTS_FOLDER / 'scikit' / case_name / f'{n_components}_components' / f'perplexity_{perplexity}' / '&'.join(rois)
     if filepath.exists():
         return pandas.read_csv(filepath, index_col=0)
     else:

--- a/TCGA/TSNE/scikit.py
+++ b/TCGA/TSNE/scikit.py
@@ -1,58 +1,114 @@
+import json
 import pandas
+import numpy
 from pathlib import Path
 from datetime import datetime
 import matplotlib.pyplot as plt
+import matplotlib.cm as cm
 from sklearn import manifold
 
 from ..read_vectors import get_case_vector
 
 
 DOWNLOADS_FOLDER = Path(__file__).parent.parent / 'downloads'
+RESULTS_FOLDER = Path(__file__).parent / 'results'
+COLUMN_NAMES = Path(__file__).parent.parent / 'column_names.json'
+CLASSIF_PREFIX = 'Unconstrained.ClassifProbab.'
+COLORMAP = 'Set1'
+
 PERPLEXITIES = [5, 30, 50, 100]
-N_COMPONENTS = 3
+NUM_COMPONENTS = 2
+MAX_ITERATIONS = 300
+NUM_ROIS = 3
+
+with open(COLUMN_NAMES) as f:
+    column_names = json.load(f)
+    classif_columns = [c for c in column_names if c.startswith(CLASSIF_PREFIX)]
+    COLOR_LABEL_KEY = {c: i for i, c in enumerate(classif_columns)}
+
+
+def get_tsne_result(case_name, roiname, n_components=2, perplexity=100):
+    filepath = RESULTS_FOLDER / 'scikit' / case_name / f'{n_components}_components' / f'perplexity_{perplexity}' / roiname
+    if filepath.exists():
+        return pandas.read_csv(filepath)
+    else:
+        if not filepath.parent.exists():
+            filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        vector = get_case_vector(case_name, rois=[roiname])
+        # remove any columns that cannot be cast to float
+        vector.drop(
+            [c for c in vector.columns if str(vector[c].dtype) != 'float64'],
+            axis=1,
+            inplace=True
+        )
+        vector.fillna(-1, inplace=True)
+        colors = [COLOR_LABEL_KEY[c] for c in vector[COLOR_LABEL_KEY.keys()].idxmax(axis=1)]
+        print(f'\tEvaluating TSNE with perplexity={perplexity} for {len(vector)} features...')
+        start = datetime.now()
+        tsne = manifold.TSNE(
+            n_components=n_components,
+            perplexity=perplexity,
+            init="random",
+            random_state=0,
+            max_iter=MAX_ITERATIONS,
+        )
+        try:
+            result = tsne.fit_transform(vector.to_numpy())
+            df = pandas.DataFrame(
+                result,
+                columns=[['x', 'y', 'z'][i] for i in range(n_components)]
+            )
+            df = df.assign(c=colors)
+            df.to_csv(filepath)
+            print(f'\tCompleted TSNE evaluation in {datetime.now() - start} seconds.')
+            return df
+        except Exception as e:
+            print('\tSkipping TSNE Evaluation:', str(e))
 
 
 for case in DOWNLOADS_FOLDER.glob('*'):
     case_features = []
     case_name = case.name.split('.')[0]
 
-    print(f'{case_name}')
-    (fig, subplots) = plt.subplots(1, 4, figsize=(15, len(PERPLEXITIES)))
-    vector = get_case_vector(case_name)
+    for roi_csv in list((case / 'nucleiMeta').glob('*.csv'))[:NUM_ROIS]:
+        roiname = roi_csv.name.replace('.csv', '')
+        print(roiname)
+        main_axes = None
+        fig = plt.figure(figsize=(15, 15), layout='tight')
+        fig.suptitle(roiname)
+        for i, perplexity in enumerate(PERPLEXITIES):
+            result = get_tsne_result(case_name, roiname, NUM_COMPONENTS, perplexity)
+            if result is not None:
+                components = [result[['x', 'y', 'z'][i]] for i in range(NUM_COMPONENTS)]
+                ax = fig.add_subplot(
+                    1,
+                    len(PERPLEXITIES),
+                    i + 1,
+                    sharex=main_axes,
+                    sharey=main_axes,
+                    title=f"Perplexity={perplexity}",
+                    projection='3d' if NUM_COMPONENTS == 3 else None,
+                )
+                ax.scatter(
+                    *components,
+                    c=result['c'],
+                    s=2,
+                    cmap=COLORMAP
+                )
+                if main_axes is None:
+                    main_axes = ax
 
-    # whole vectors take 40-70 minutes; test with just one ROI
-    # comment the following two lines to compute whole image:
-    target_roi = vector['roiname'].mode()[0]
-    vector = vector[vector['roiname'] == target_roi]
-
-    # remove any columns that cannot be cast to float
-    vector.drop(
-        [c for c in vector.columns if str(vector[c].dtype) != 'float64'],
-        axis=1,
-        inplace=True
-    )
-    vector.fillna(-1, inplace=True)
-
-    for i, perplexity in enumerate(PERPLEXITIES):
-        print(f'\tEvaluating TSNE with perplexity={perplexity} for {len(vector)} features...')
-        start = datetime.now()
-        ax = subplots[i]
-
-        tsne = manifold.TSNE(
-            n_components=N_COMPONENTS,
-            init="random",
-            random_state=0,
-            perplexity=perplexity,
-            max_iter=300,
+        cbar = fig.colorbar(
+            cm.ScalarMappable(cmap=COLORMAP),
+            ax=ax,
+            label='Classification',
         )
-        result = tsne.fit_transform(vector.to_numpy())
-        print(f'\tCompleted TSNE evaluation  in {datetime.now() - start} seconds.')
-
-        ax.set_title(f"Perplexity={perplexity}")
-        ax.scatter(
-            result[:, 0],
-            result[:, 1],
-            c=(result[:, 2] if N_COMPONENTS == 3 else 'g'),
+        yticks = numpy.linspace(*cbar.ax.get_ylim(), len(COLOR_LABEL_KEY) + 1)[:-1]
+        yticks += (yticks[1] - yticks[0]) / 2
+        cbar.set_ticks(
+            yticks,
+            labels=[c.replace(CLASSIF_PREFIX, '') for c in COLOR_LABEL_KEY.keys()],
         )
-
-plt.show()
+        cbar.ax.tick_params(length=0)
+        plt.show()

--- a/TCGA/TSNE/umap.py
+++ b/TCGA/TSNE/umap.py
@@ -1,0 +1,60 @@
+import pandas
+from datetime import datetime
+from sklearn.preprocessing import normalize
+import umap
+
+from ..read_vectors import get_case_vector
+from ..constants import TSNE_RESULTS_FOLDER, TSNE_EXCLUDE_COLUMNS
+
+
+def get_umap_result(
+    case_name,
+    rois,
+    color_label_key=None,
+    vector=None
+):
+    filename = 'all.csv'
+    if rois is not None:
+        filename = '&'.join(rois) + '.csv'
+    filepath = TSNE_RESULTS_FOLDER / 'umap' / case_name / filename
+    if filepath.exists():
+        return pandas.read_csv(filepath, index_col=0)
+    else:
+        if not filepath.parent.exists():
+            filepath.parent.mkdir(parents=True, exist_ok=True)
+
+        if vector is None:
+            vector = get_case_vector(case_name, rois=rois)
+        if color_label_key is not None:
+            colors = [color_label_key[c] for c in vector[color_label_key.keys()].idxmax(axis=1)]
+        else:
+            colors = None
+
+        # remove any columns that cannot be cast to float
+        vector.drop(
+            [
+                c for c in vector.columns
+                if str(vector[c].dtype) != 'float64' or c in TSNE_EXCLUDE_COLUMNS
+            ],
+            axis=1,
+            inplace=True
+        )
+        vector.fillna(-1, inplace=True)
+        normalize(vector, axis=1, norm='l1')
+
+        print(f'\tEvaluating UMAP for {len(vector)} features...')
+        start = datetime.now()
+        reducer = umap.UMAP()
+        try:
+            result = reducer.fit_transform(vector.to_numpy())
+            df = pandas.DataFrame(
+                result,
+                columns=['x', 'y']
+            )
+            if colors is not None:
+                df = df.assign(c=colors)
+            df.to_csv(filepath)
+            print(f'\tCompleted TSNE evaluation in {datetime.now() - start} seconds.')
+            return df
+        except Exception as e:
+            print('\tSkipping TSNE Evaluation:', str(e))

--- a/TCGA/constants.py
+++ b/TCGA/constants.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+from matplotlib import colormaps
+
+
+DOWNLOADS_FOLDER = Path(__file__).parent / 'downloads'
+ANNOTATIONS_FOLDER = Path(__file__).parent / 'annotations'
+TSNE_RESULTS_FOLDER = Path(__file__).parent / 'TSNE' / 'results'
+
+COLUMN_NAMES = Path(__file__).parent / 'column_names.json'
+CLASSIF_PREFIX = 'Unconstrained.ClassifProbab.'
+COLORMAP = colormaps['Set1']
+
+INCLUDE_TSNE = True
+TSNE_PERPLEXITY = 100
+TSNE_NUM_COMPONENTS = 2
+ROIS = [
+    "TCGA-3C-AALI-01Z-00-DX1_roi-2_left-15953_top-51923_right-18001_bottom-53971",
+    "TCGA-3C-AALI-01Z-00-DX1_roi-3_left-15953_top-53971_right-18001_bottom-56019",
+    "TCGA-3C-AALI-01Z-00-DX1_roi-4_left-15953_top-56019_right-18001_bottom-58067",
+]
+
+OVERWRITE = True
+
+with open(COLUMN_NAMES) as f:
+    column_names = json.load(f)
+    classif_columns = [c for c in column_names if c.startswith(CLASSIF_PREFIX)]
+    COLOR_LABEL_KEY = {c: i for i, c in enumerate(classif_columns)}
+
+
+with open('conf.json') as f:
+    CONF = json.load(f)

--- a/TCGA/constants.py
+++ b/TCGA/constants.py
@@ -34,6 +34,9 @@ TSNE_EXCLUDE_COLUMNS = [
     "Identifier.WeightedCentroidY",
 ]
 
+
+# Specify None to cover all ROIS
+# ROIS = None
 ROIS = [
     "TCGA-3C-AALI-01Z-00-DX1_roi-2_left-15953_top-51923_right-18001_bottom-53971",
     "TCGA-3C-AALI-01Z-00-DX1_roi-3_left-15953_top-53971_right-18001_bottom-56019",

--- a/TCGA/constants.py
+++ b/TCGA/constants.py
@@ -14,6 +14,26 @@ COLORMAP = colormaps['Set1']
 INCLUDE_TSNE = True
 TSNE_PERPLEXITY = 100
 TSNE_NUM_COMPONENTS = 2
+TSNE_EXCLUDE_COLUMNS = [
+    "Identifier.ObjectCode",
+    "Identifier.Xmin",
+    "Identifier.Ymin",
+    "Identifier.Xmax",
+    "Identifier.Ymax",
+    "Identifier.CentroidX",
+    "Identifier.CentroidY",
+    "Unconstrained.Identifier.Xmin",
+    "Unconstrained.Identifier.Ymin",
+    "Unconstrained.Identifier.Xmax",
+    "Unconstrained.Identifier.Ymax",
+    "Unconstrained.Identifier.CentroidX",
+    "Unconstrained.Identifier.CentroidY",
+    "slide",
+    "roiname",
+    "Identifier.WeightedCentroidX",
+    "Identifier.WeightedCentroidY",
+]
+
 ROIS = [
     "TCGA-3C-AALI-01Z-00-DX1_roi-2_left-15953_top-51923_right-18001_bottom-53971",
     "TCGA-3C-AALI-01Z-00-DX1_roi-3_left-15953_top-53971_right-18001_bottom-56019",

--- a/TCGA/download_examples.py
+++ b/TCGA/download_examples.py
@@ -3,15 +3,10 @@ import json
 
 from datetime import datetime
 from pathlib import Path
+from .constants import DOWNLOADS_FOLDER, CONF
 
 
-DOWNLOADS_FOLDER = Path(__file__).parent / 'downloads'
-
-
-with open('conf.json') as f:
-    conf = json.load(f)
-
-sample_data_server = conf.get('sample_data_server', {})
+sample_data_server = CONF.get('sample_data_server', {})
 api_root = sample_data_server.get('api_root')
 folder_id = sample_data_server.get('folder_id')
 

--- a/TCGA/read_vectors.py
+++ b/TCGA/read_vectors.py
@@ -1,12 +1,5 @@
-import girder_client
-import json
-import math
 import pandas
-from pathlib import Path
-from datetime import datetime
-
-
-DOWNLOADS_FOLDER = Path(__file__).parent / 'downloads'
+from .constants import DOWNLOADS_FOLDER
 
 
 def get_case_vector(case_name, rois=None):

--- a/TCGA/read_vectors.py
+++ b/TCGA/read_vectors.py
@@ -1,0 +1,45 @@
+import girder_client
+import json
+import math
+import pandas
+from pathlib import Path
+from datetime import datetime
+
+
+DOWNLOADS_FOLDER = Path(__file__).parent / 'downloads'
+
+
+def get_case_vector(case_name):
+    results = None
+    case_folder = next(DOWNLOADS_FOLDER.glob(case_name))
+    meta_vectors = case_folder / 'nucleiMeta'
+    prop_vectors = case_folder / 'nucleiProps'
+    meta_vector_files = list(meta_vectors.glob('*.csv'))
+    prop_vector_files = list(prop_vectors.glob('*.csv'))
+    print(f'\tReading features in {len(meta_vector_files)} regions.')
+
+    for meta_vector_file in meta_vector_files:
+        prop_vector_file = next((
+            f for f in prop_vector_files
+            if f.name == meta_vector_file.name
+        ), None)
+        if prop_vector_file:
+            meta = pandas.read_csv(
+                str(meta_vector_file),
+                usecols=lambda x: 'Unnamed' not in x
+            ).reset_index(drop=True)
+            props = pandas.read_csv(
+                str(prop_vector_file),
+                usecols=lambda x: 'Unnamed' not in x
+            ).reset_index(drop=True)
+            intersection_cols = list(meta.columns.intersection(props.columns))
+            # print(intersection_cols)
+            props = props.drop(intersection_cols, axis=1)
+            vector = pandas.concat([meta, props], axis=1)
+            if results is None:
+                results = vector
+            else:
+                results = pandas.concat([results, vector])
+        else:
+            print('No prop file for', meta_vector_file.name)
+    return results

--- a/TCGA/read_vectors.py
+++ b/TCGA/read_vectors.py
@@ -9,38 +9,41 @@ from datetime import datetime
 DOWNLOADS_FOLDER = Path(__file__).parent / 'downloads'
 
 
-def get_case_vector(case_name):
+def get_case_vector(case_name, rois=None):
     results = None
     case_folder = next(DOWNLOADS_FOLDER.glob(case_name))
     meta_vectors = case_folder / 'nucleiMeta'
     prop_vectors = case_folder / 'nucleiProps'
     meta_vector_files = list(meta_vectors.glob('*.csv'))
     prop_vector_files = list(prop_vectors.glob('*.csv'))
-    print(f'\tReading features in {len(meta_vector_files)} regions.')
+    num_regions = len(meta_vector_files) if rois is None else len(rois)
+    print(f'\tReading features in {num_regions} region(s).')
 
     for meta_vector_file in meta_vector_files:
-        prop_vector_file = next((
-            f for f in prop_vector_files
-            if f.name == meta_vector_file.name
-        ), None)
-        if prop_vector_file:
-            meta = pandas.read_csv(
-                str(meta_vector_file),
-                usecols=lambda x: 'Unnamed' not in x
-            ).reset_index(drop=True)
-            props = pandas.read_csv(
-                str(prop_vector_file),
-                usecols=lambda x: 'Unnamed' not in x
-            ).reset_index(drop=True)
-            intersection_cols = list(meta.columns.intersection(props.columns))
-            # print(intersection_cols)
-            props = props.drop(intersection_cols, axis=1)
-            vector = pandas.concat([meta, props], axis=1)
-            if results is None:
-                results = vector
+        roi_name = meta_vector_file.name.replace('.csv', '')
+        if rois is None or roi_name in rois:
+            prop_vector_file = next((
+                f for f in prop_vector_files
+                if f.name == meta_vector_file.name
+            ), None)
+            if prop_vector_file:
+                meta = pandas.read_csv(
+                    str(meta_vector_file),
+                    usecols=lambda x: 'Unnamed' not in x
+                ).reset_index(drop=True)
+                props = pandas.read_csv(
+                    str(prop_vector_file),
+                    usecols=lambda x: 'Unnamed' not in x
+                ).reset_index(drop=True)
+                intersection_cols = list(meta.columns.intersection(props.columns))
+                # print(intersection_cols)
+                props = props.drop(intersection_cols, axis=1)
+                vector = pandas.concat([meta, props], axis=1)
+                if results is None:
+                    results = vector
+                else:
+                    results = pandas.concat([results, vector])
             else:
-                results = pandas.concat([results, vector])
-        else:
-            print('No prop file for', meta_vector_file.name)
+                print('No prop file for', meta_vector_file.name)
     print(f'\tFound {len(results)} features.')
     return results

--- a/TCGA/read_vectors.py
+++ b/TCGA/read_vectors.py
@@ -42,4 +42,5 @@ def get_case_vector(case_name):
                 results = pandas.concat([results, vector])
         else:
             print('No prop file for', meta_vector_file.name)
+    print(f'\tFound {len(results)} features.')
     return results

--- a/TCGA/upload_annotations.py
+++ b/TCGA/upload_annotations.py
@@ -4,17 +4,10 @@ import json
 import getpass
 
 from datetime import datetime
-from pathlib import Path
+from .constants import ANNOTATIONS_FOLDER, CONF, OVERWRITE
 
 
-ANNOTATIONS_FOLDER = Path(__file__).parent / 'annotations'
-OVERWRITE = True
-
-
-with open('conf.json') as f:
-    conf = json.load(f)
-
-target_server = conf.get('target_server', {})
+target_server = CONF.get('target_server', {})
 api_root = target_server.get('api_root')
 folder_id = target_server.get('folder_id')
 username = input('Username: ')

--- a/TCGA/upload_annotations.py
+++ b/TCGA/upload_annotations.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 
 ANNOTATIONS_FOLDER = Path(__file__).parent / 'annotations'
+OVERWRITE = True
 
 
 with open('conf.json') as f:
@@ -35,6 +36,16 @@ for case in ANNOTATIONS_FOLDER.glob('*.json'):
         annotation_contents = json.load(f)
     for item in client.listItem(folder_id, case_name):
         print('\t', item.get('name'))
+        if OVERWRITE:
+            for old_annotation in client.get(
+                'annotation',
+                parameters=dict(itemId=item['_id']),
+            ):
+                old_id = old_annotation.get('_id')
+                print(f'\t Deleting old annotation {old_id}.')
+                client.delete(
+                    f'annotation/{old_id}',
+                )
         client.post(
             'annotation',
             parameters=dict(itemId=item['_id']),

--- a/TCGA/upload_images.py
+++ b/TCGA/upload_images.py
@@ -1,18 +1,11 @@
 import girder_client
-import json
 import getpass
-
 from datetime import datetime
-from pathlib import Path
+
+from .constants import DOWNLOADS_FOLDER, CONF
 
 
-DOWNLOADS_FOLDER = Path(__file__).parent / 'downloads'
-
-
-with open('conf.json') as f:
-    conf = json.load(f)
-
-target_server = conf.get('target_server', {})
+target_server = CONF.get('target_server', {})
 api_root = target_server.get('api_root')
 folder_id = target_server.get('folder_id')
 username = input('Username: ')

--- a/TCGA/write_annotations.py
+++ b/TCGA/write_annotations.py
@@ -33,6 +33,7 @@ for case in DOWNLOADS_FOLDER.glob('*'):
             n_components=TSNE_NUM_COMPONENTS,
             perplexity=TSNE_PERPLEXITY,
             color_label_key=COLOR_LABEL_KEY,
+            vector=vector,
         )
 
     # assumes roiname is a string like "TCGA-3C-AALI-01Z-00-DX1_roi-0_left-15953_top-45779_right-18001_bottom-47827"
@@ -86,6 +87,7 @@ for case in DOWNLOADS_FOLDER.glob('*'):
                     type='ellipse',
                     lineColor=color,
                     lineWidth=2,
+                    fillColor=color,
                     center=[centroidX, centroidY, 0],
                     width=minor * 2,
                     height=major * 2,

--- a/TCGA/write_annotations.py
+++ b/TCGA/write_annotations.py
@@ -1,36 +1,19 @@
-import girder_client
 import json
-import math
-import pandas
-from pathlib import Path
 from datetime import datetime
-from matplotlib import colormaps
 from matplotlib.colors import to_hex
 
 from .read_vectors import get_case_vector
 from .TSNE.scikit import get_tsne_result
-
-
-DOWNLOADS_FOLDER = Path(__file__).parent / 'downloads'
-ANNOTATIONS_FOLDER = Path(__file__).parent / 'annotations'
-COLUMN_NAMES = Path(__file__).parent / 'column_names.json'
-CLASSIF_PREFIX = 'Unconstrained.ClassifProbab.'
-COLORMAP = colormaps['Set1']
-
-INCLUDE_TSNE = True
-TSNE_PERPLEXITY = 100
-TSNE_NUM_COMPONENTS = 2
-ROIS = [
-    "TCGA-3C-AALI-01Z-00-DX1_roi-2_left-15953_top-51923_right-18001_bottom-53971",
-    "TCGA-3C-AALI-01Z-00-DX1_roi-3_left-15953_top-53971_right-18001_bottom-56019",
-    "TCGA-3C-AALI-01Z-00-DX1_roi-4_left-15953_top-56019_right-18001_bottom-58067",
-]
-
-with open(COLUMN_NAMES) as f:
-    column_names = json.load(f)
-    classif_columns = [c for c in column_names if c.startswith(CLASSIF_PREFIX)]
-    COLOR_LABEL_KEY = {c: i for i, c in enumerate(classif_columns)}
-
+from .constants import (
+    DOWNLOADS_FOLDER,
+    ANNOTATIONS_FOLDER,
+    ROIS,
+    INCLUDE_TSNE,
+    TSNE_NUM_COMPONENTS,
+    TSNE_PERPLEXITY,
+    COLOR_LABEL_KEY,
+    COLORMAP,
+)
 
 print(f'Converting feature vectors to annotations...')
 start = datetime.now()

--- a/TCGA/write_annotations.py
+++ b/TCGA/write_annotations.py
@@ -12,10 +12,16 @@ from .TSNE.scikit import get_tsne_result
 
 DOWNLOADS_FOLDER = Path(__file__).parent / 'downloads'
 ANNOTATIONS_FOLDER = Path(__file__).parent / 'annotations'
-NUM_ROIS = 1
+
 INCLUDE_TSNE = True
 TSNE_PERPLEXITY = 100
 TSNE_NUM_COMPONENTS = 2
+ROIS = [
+    "TCGA-3C-AALI-01Z-00-DX1_roi-2_left-15953_top-51923_right-18001_bottom-53971",
+    "TCGA-3C-AALI-01Z-00-DX1_roi-3_left-15953_top-53971_right-18001_bottom-56019",
+    "TCGA-3C-AALI-01Z-00-DX1_roi-4_left-15953_top-56019_right-18001_bottom-58067",
+]
+
 
 
 print(f'Converting feature vectors to annotations...')
@@ -26,66 +32,70 @@ for case in DOWNLOADS_FOLDER.glob('*'):
     case_features = []
     case_name = case.name.split('.')[0]
     print(f'\t{case_name}')
+    vector = get_case_vector(case_name, rois=ROIS)
 
-    vector = get_case_vector(case_name, rois=[
-        f.name.replace('.csv', '') for f in list((case / 'nucleiMeta').glob('*.csv'))[:NUM_ROIS]
-    ])
+    tsne_result = None
+    if INCLUDE_TSNE:
+        tsne_result = get_tsne_result(
+            case_name,
+            ROIS,
+            TSNE_NUM_COMPONENTS,
+            TSNE_PERPLEXITY
+        )
 
     # assumes roiname is a string like "TCGA-3C-AALI-01Z-00-DX1_roi-0_left-15953_top-45779_right-18001_bottom-47827"
     for roi_name, roi_group in vector.groupby('roiname'):
-        components = roi_name.replace(f'{case_name}_', '').split('_')
-        region = {}
-        for component in components:
-            key, value = component.split('-')
-            if key != 'roi':
-                region[key] = int(value)
-        # print(region)
-        roi_center = [
-            (region.get('right') + region.get('left')) / 2,
-            (region.get('bottom') + region.get('top')) / 2,
-        ]
-        case_features.append(dict(
-            type='rectangle',
-            lineColor='#FF0000',
-            lineWidth=2,
-            center=[*roi_center, 0],
-            width=(region.get('right') - region.get('left')),
-            height=(region.get('bottom') - region.get('top')),
-        ))
-        tsne_result = None
-        if INCLUDE_TSNE:
-            tsne_result = get_tsne_result(case_name, roi_name, TSNE_NUM_COMPONENTS, TSNE_PERPLEXITY)
-        for index, feature in roi_group.iterrows():
-            major, minor, centroidX, centroidY, orientation = [
-                feature['Size.MajorAxisLength'],
-                feature['Size.MinorAxisLength'],
-                feature['Unconstrained.Identifier.CentroidX'],
-                feature['Unconstrained.Identifier.CentroidY'],
-                feature['Orientation.Orientation'],
+        if roi_name in ROIS:
+            components = roi_name.replace(f'{case_name}_', '').split('_')
+            region = {}
+            for component in components:
+                key, value = component.split('-')
+                if key != 'roi':
+                    region[key] = int(value)
+            # print(region)
+            roi_center = [
+                (region.get('right') + region.get('left')) / 2,
+                (region.get('bottom') + region.get('top')) / 2,
             ]
-            # Only multiply by 2 if getMetadata().getMagnification() is 40 (CSV data done at 20x)
-            # coordinates are relative to ROI and half resolution
-            centroidX *= 2
-            centroidY *= 2
-            centroidX += region.get('left', 0)
-            centroidY += region.get('top', 0)
-
-            meta = dict(
-                id=feature['Identifier.ObjectCode']
-            )
-            if tsne_result is not None:
-                meta.update({f'tsne_{k}': v for k, v in tsne_result.iloc[index].to_dict().items()})
-
             case_features.append(dict(
-                type='ellipse',
-                lineColor='#00FF00',
+                type='rectangle',
+                lineColor='#FF0000',
                 lineWidth=2,
-                center=[centroidX, centroidY, 0],
-                width=minor * 2,
-                height=major * 2,
-                rotation=(0 - orientation),  # negated orientation
-                user=meta  # adhere to schema; user is unconstrained
+                center=[*roi_center, 0],
+                width=(region.get('right') - region.get('left')),
+                height=(region.get('bottom') - region.get('top')),
             ))
+            for index, feature in roi_group.iterrows():
+                major, minor, centroidX, centroidY, orientation = [
+                    feature['Size.MajorAxisLength'],
+                    feature['Size.MinorAxisLength'],
+                    feature['Unconstrained.Identifier.CentroidX'],
+                    feature['Unconstrained.Identifier.CentroidY'],
+                    feature['Orientation.Orientation'],
+                ]
+                # Only multiply by 2 if getMetadata().getMagnification() is 40 (CSV data done at 20x)
+                # coordinates are relative to ROI and half resolution
+                centroidX *= 2
+                centroidY *= 2
+                centroidX += region.get('left', 0)
+                centroidY += region.get('top', 0)
+
+                meta = dict(
+                    id=feature['Identifier.ObjectCode']
+                )
+                if tsne_result is not None:
+                    meta.update({f'tsne_{k}': v for k, v in tsne_result.iloc[index].to_dict().items()})
+
+                case_features.append(dict(
+                    type='ellipse',
+                    lineColor='#00FF00',
+                    lineWidth=2,
+                    center=[centroidX, centroidY, 0],
+                    width=minor * 2,
+                    height=major * 2,
+                    rotation=(0 - orientation),  # negated orientation
+                    user=meta  # adhere to schema; user is unconstrained
+                ))
 
     # export case_features to annotation file
     annotation = dict(

--- a/TCGA/write_annotations.py
+++ b/TCGA/write_annotations.py
@@ -6,12 +6,11 @@ from pathlib import Path
 from datetime import datetime
 
 
+from .read_vectors import get_case_vector
+
+
 DOWNLOADS_FOLDER = Path(__file__).parent / 'downloads'
 ANNOTATIONS_FOLDER = Path(__file__).parent / 'annotations'
-
-
-with open('conf.json') as f:
-    conf = json.load(f)
 
 
 print(f'Converting feature vectors to annotations...')
@@ -23,85 +22,52 @@ for case in DOWNLOADS_FOLDER.glob('*'):
     case_name = case.name.split('.')[0]
 
     print(f'\t{case_name}')
+    vector = get_case_vector(case_name)
 
-    meta_vectors = case / 'nucleiMeta'
-    prop_vectors = case / 'nucleiProps'
-
-    meta_vector_files = list(meta_vectors.glob('*.csv'))
-    prop_vector_files = list(prop_vectors.glob('*.csv'))
-
-    print(f'\tReading features in {len(meta_vector_files)} regions.')
-
-    if meta_vectors.exists() and prop_vectors.exists():
-        for meta_vector_file in meta_vector_files:
-            prop_vector_file = next((
-                f for f in prop_vector_files
-                if f.name == meta_vector_file.name
-            ), None)
-            if prop_vector_file:
-                meta = pandas.read_csv(
-                    str(meta_vector_file),
-                    usecols=lambda x: 'Unnamed' not in x
-                ).reset_index(drop=True)
-                props = pandas.read_csv(
-                    str(prop_vector_file),
-                    usecols=lambda x: 'Unnamed' not in x
-                ).reset_index(drop=True)
-                intersection_cols = list(meta.columns.intersection(props.columns))
-                # print(intersection_cols)
-                props = props.drop(intersection_cols, axis=1)
-                combo = pandas.concat([meta, props], axis=1)
-                # print(meta.shape, props.shape, combo.shape)
-                # print(list(combo.columns))
-
-                # assumes roiname is a string like "TCGA-3C-AALI-01Z-00-DX1_roi-0_left-15953_top-45779_right-18001_bottom-47827"
-                for roiname in combo['roiname'].mode():
-                    components = roiname.replace(f'{case_name}_', '').split('_')
-                    region = {}
-                    for component in components:
-                        key, value = component.split('-')
-                        if key != 'roi':
-                            region[key] = int(value)
-                    # print(region)
-                    roi_center = [
-                        (region.get('right') + region.get('left')) / 2,
-                        (region.get('bottom') + region.get('top')) / 2,
-                    ]
-                    case_features.append(dict(
-                        type='rectangle',
-                        lineColor='#FF0000',
-                        lineWidth=2,
-                        center=[*roi_center, 0],
-                        width=(region.get('right') - region.get('left')),
-                        height=(region.get('bottom') - region.get('top')),
-                    ))
-                    for index, feature in combo[combo['roiname'] == roiname].iterrows():
-                        major, minor, centroidX, centroidY, orientation = [
-                            feature['Size.MajorAxisLength'],
-                            feature['Size.MinorAxisLength'],
-                            feature['Unconstrained.Identifier.CentroidX'],
-                            feature['Unconstrained.Identifier.CentroidY'],
-                            feature['Orientation.Orientation'],
-                        ]
-                        # Only multiply by 2 if getMetadata().getMagnification() is 40 (CSV data done at 20x)
-                        # coordinates are relative to ROI and half resolution
-                        centroidX *= 2
-                        centroidY *= 2
-                        centroidX += region.get('left', 0)
-                        centroidY += region.get('top', 0)
-                        case_features.append(dict(
-                            type='ellipse',
-                            lineColor='#00FF00',
-                            lineWidth=2,
-                            center=[centroidX, centroidY, 0],
-                            width=minor * 2,
-                            height=major * 2,
-                            rotation=(0 - orientation),  # negated orientation
-                        ))
-            else:
-                print('No prop file for', meta_vector_file.name)
-    else:
-        print('No feature vector data found for', case_name)
+    # assumes roiname is a string like "TCGA-3C-AALI-01Z-00-DX1_roi-0_left-15953_top-45779_right-18001_bottom-47827"
+    for roi_name, roi_group in vector.groupby('roiname'):
+        components = roi_name.replace(f'{case_name}_', '').split('_')
+        region = {}
+        for component in components:
+            key, value = component.split('-')
+            if key != 'roi':
+                region[key] = int(value)
+        # print(region)
+        roi_center = [
+            (region.get('right') + region.get('left')) / 2,
+            (region.get('bottom') + region.get('top')) / 2,
+        ]
+        case_features.append(dict(
+            type='rectangle',
+            lineColor='#FF0000',
+            lineWidth=2,
+            center=[*roi_center, 0],
+            width=(region.get('right') - region.get('left')),
+            height=(region.get('bottom') - region.get('top')),
+        ))
+        for index, feature in roi_group.iterrows():
+            major, minor, centroidX, centroidY, orientation = [
+                feature['Size.MajorAxisLength'],
+                feature['Size.MinorAxisLength'],
+                feature['Unconstrained.Identifier.CentroidX'],
+                feature['Unconstrained.Identifier.CentroidY'],
+                feature['Orientation.Orientation'],
+            ]
+            # Only multiply by 2 if getMetadata().getMagnification() is 40 (CSV data done at 20x)
+            # coordinates are relative to ROI and half resolution
+            centroidX *= 2
+            centroidY *= 2
+            centroidX += region.get('left', 0)
+            centroidY += region.get('top', 0)
+            case_features.append(dict(
+                type='ellipse',
+                lineColor='#00FF00',
+                lineWidth=2,
+                center=[centroidX, centroidY, 0],
+                width=minor * 2,
+                height=major * 2,
+                rotation=(0 - orientation),  # negated orientation
+            ))
 
     # export case_features to annotation file
     annotation = dict(

--- a/TCGA/write_annotations.py
+++ b/TCGA/write_annotations.py
@@ -33,12 +33,12 @@ for case in DOWNLOADS_FOLDER.glob('*'):
             n_components=TSNE_NUM_COMPONENTS,
             perplexity=TSNE_PERPLEXITY,
             color_label_key=COLOR_LABEL_KEY,
-            vector=vector,
+            vector=vector.copy(),
         )
 
     # assumes roiname is a string like "TCGA-3C-AALI-01Z-00-DX1_roi-0_left-15953_top-45779_right-18001_bottom-47827"
     for roi_name, roi_group in vector.groupby('roiname'):
-        if roi_name in ROIS:
+        if ROIS is not None and roi_name in ROIS:
             components = roi_name.replace(f'{case_name}_', '').split('_')
             region = {}
             for component in components:

--- a/TCGA/write_annotations.py
+++ b/TCGA/write_annotations.py
@@ -4,7 +4,8 @@ import math
 import pandas
 from pathlib import Path
 from datetime import datetime
-
+from matplotlib import colormaps
+from matplotlib.colors import to_hex
 
 from .read_vectors import get_case_vector
 from .TSNE.scikit import get_tsne_result
@@ -12,6 +13,9 @@ from .TSNE.scikit import get_tsne_result
 
 DOWNLOADS_FOLDER = Path(__file__).parent / 'downloads'
 ANNOTATIONS_FOLDER = Path(__file__).parent / 'annotations'
+COLUMN_NAMES = Path(__file__).parent / 'column_names.json'
+CLASSIF_PREFIX = 'Unconstrained.ClassifProbab.'
+COLORMAP = colormaps['Set1']
 
 INCLUDE_TSNE = True
 TSNE_PERPLEXITY = 100
@@ -22,6 +26,10 @@ ROIS = [
     "TCGA-3C-AALI-01Z-00-DX1_roi-4_left-15953_top-56019_right-18001_bottom-58067",
 ]
 
+with open(COLUMN_NAMES) as f:
+    column_names = json.load(f)
+    classif_columns = [c for c in column_names if c.startswith(CLASSIF_PREFIX)]
+    COLOR_LABEL_KEY = {c: i for i, c in enumerate(classif_columns)}
 
 
 print(f'Converting feature vectors to annotations...')
@@ -39,8 +47,9 @@ for case in DOWNLOADS_FOLDER.glob('*'):
         tsne_result = get_tsne_result(
             case_name,
             ROIS,
-            TSNE_NUM_COMPONENTS,
-            TSNE_PERPLEXITY
+            n_components=TSNE_NUM_COMPONENTS,
+            perplexity=TSNE_PERPLEXITY,
+            color_label_key=COLOR_LABEL_KEY,
         )
 
     # assumes roiname is a string like "TCGA-3C-AALI-01Z-00-DX1_roi-0_left-15953_top-45779_right-18001_bottom-47827"
@@ -80,15 +89,19 @@ for case in DOWNLOADS_FOLDER.glob('*'):
                 centroidX += region.get('left', 0)
                 centroidY += region.get('top', 0)
 
+                color = '#00FF00'
                 meta = dict(
                     id=feature['Identifier.ObjectCode']
                 )
                 if tsne_result is not None:
                     meta.update({f'tsne_{k}': v for k, v in tsne_result.iloc[index].to_dict().items()})
+                    c = meta.get('tsne_c')
+                    if c is not None:
+                        color = to_hex(COLORMAP.colors[int(c)])
 
                 case_features.append(dict(
                     type='ellipse',
-                    lineColor='#00FF00',
+                    lineColor=color,
                     lineWidth=2,
                     center=[centroidX, centroidY, 0],
                     width=minor * 2,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 girder-client
 pandas
 scikit-learn
+umap-learn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 girder-client
 pandas
+scikit-learn


### PR DESCRIPTION
This PR creates a folder for experiments regarding dimensionality reduction. 

Running `python -m TCGA.TSNE.display_tsne` takes about 30 seconds (for 4 different computations) and displays the following visualization:
![image](https://github.com/user-attachments/assets/ee5143ee-a453-4ab8-abc3-36e87d7c2d21)

Running `python -m TCGA.TSNE.display_umap` takes about 10 seconds and displays the following visualization:
![image](https://github.com/user-attachments/assets/dc465539-b09a-444b-b6bb-8cc8986c03ec)

The above visualizations are defaulted to only 3 (adjacent) ROIs defined in `TCGA/constants.py`. Setting `ROIS=None` will compute dimensionality reduction over the whole sample image. 

Doing all ROIs for TSNE takes 52 minutes and 6 seconds, resulting in the following scatter plot:
![image](https://github.com/user-attachments/assets/d355528f-9c7f-4aff-a2ff-6c2b295760ac)

Doing all ROIs for UMAP takes 5 minutes and 12 seconds, resulting in the following scatter plot:
![image](https://github.com/user-attachments/assets/5ccf5023-d548-46cc-835e-fa610cd31592)

Note: these computations were performed by excluding certain columns from the feature vector. Any columns related to location (centroid X, Y, etc,) were dropped before computing dimensionality reduction. The list of excluded columns can be configured in `TCGA/constants.py`.